### PR TITLE
Fix to type hint and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We also provide preprocessed example data files from the Neural Latents Benchmar
 
 ## Model Configuration
 Next, you'll need to create a model configuration file that defines the architecture of your LFADS model (e.g. `configs/model/my_model.yaml`). We recommend starting with a copy of the `configs/model/nlb_mc_maze.yaml` file. At the least, you'll need to specify the following values in this file with the parameters of your dataset:
-- `encod_data_dim`: The `n_channels` dimension of `encod_data` from your data file.
+- `encod_data_dim`: The `n_channels` dimension of `encod_data` from your data file. Note for multi-session runs: when using principal component regression for neural stitching, this should match the dimension of the shared space rathern than the original dimensionality of the data.
 - `encod_seq_len`: The `n_timesteps` dimension of `encod_data` from your data file.
 - `recon_seq_len`: The `n_timesteps` dimension of `recon_data` from your data file.
 - `readout.modules.0.out_features`: The `n_channels` dimension of `recon_data` from your data file.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We also provide preprocessed example data files from the Neural Latents Benchmar
 
 ## Model Configuration
 Next, you'll need to create a model configuration file that defines the architecture of your LFADS model (e.g. `configs/model/my_model.yaml`). We recommend starting with a copy of the `configs/model/nlb_mc_maze.yaml` file. At the least, you'll need to specify the following values in this file with the parameters of your dataset:
-- `encod_data_dim`: The `n_channels` dimension of `encod_data` from your data file. Note for multi-session runs: when using principal component regression for neural stitching, this should match the dimension of the shared space rathern than the original dimensionality of the data.
+- `encod_data_dim`: The `n_channels` dimension of `encod_data` from your data file. Note for multi-session runs: when using principal component regression for neural stitching, this should match the dimension of the shared space rather than the original dimensionality of the data.
 - `encod_seq_len`: The `n_timesteps` dimension of `encod_data` from your data file.
 - `recon_seq_len`: The `n_timesteps` dimension of `recon_data` from your data file.
 - `readout.modules.0.out_features`: The `n_channels` dimension of `recon_data` from your data file.

--- a/lfads_torch/callbacks.py
+++ b/lfads_torch/callbacks.py
@@ -103,7 +103,6 @@ class RasterPlot(pl.Callback):
         # Compute model output
         output = pl_module.predict_step(
             batch=batch,
-            batch_ix=None,
             sample_posteriors=True,
         )
         # Discard the extra data - only the SessionBatches are relevant here

--- a/lfads_torch/callbacks.py
+++ b/lfads_torch/callbacks.py
@@ -103,6 +103,7 @@ class RasterPlot(pl.Callback):
         # Compute model output
         output = pl_module.predict_step(
             batch=batch,
+            batch_idx=None,
             sample_posteriors=True,
         )
         # Discard the extra data - only the SessionBatches are relevant here

--- a/lfads_torch/model.py
+++ b/lfads_torch/model.py
@@ -196,7 +196,7 @@ class LFADS(pl.LightningModule):
         batch: Dict[int, SessionBatch],
         sample_posteriors: bool = False,
         output_means: bool = True,
-    ) -> Dict[SessionOutput]:
+    ) -> Dict[int,SessionOutput]:
         """
         Forward pass through the model.
 

--- a/lfads_torch/model.py
+++ b/lfads_torch/model.py
@@ -510,7 +510,6 @@ class LFADS(pl.LightningModule):
     def predict_step(
         self,
         batch: Dict[int, Tuple[SessionBatch, Tuple[torch.Tensor]]],
-        batch_idx: int,
         sample_posteriors=True,
     ):
         """

--- a/lfads_torch/model.py
+++ b/lfads_torch/model.py
@@ -1,4 +1,4 @@
-from typing import Dict, Literal, Tuple
+from typing import Any, Dict, Literal, Tuple, Union
 
 import pytorch_lightning as pl
 import torch
@@ -196,7 +196,7 @@ class LFADS(pl.LightningModule):
         batch: Dict[int, SessionBatch],
         sample_posteriors: bool = False,
         output_means: bool = True,
-    ) -> Dict[int,SessionOutput]:
+    ) -> Dict[int, SessionOutput]:
         """
         Forward pass through the model.
 
@@ -273,7 +273,7 @@ class LFADS(pl.LightningModule):
         # Return the parameter estimates and all intermediate activations
         return {s: SessionOutput(*o) for s, o in zip(sessions, output)}
 
-    def configure_optimizers(self):
+    def configure_optimizers(self) -> Union[torch.optim.Optimizer, Dict[str, Any]]:
         """
         Configures the optimizers for the model.
 
@@ -342,7 +342,7 @@ class LFADS(pl.LightningModule):
         batch: Dict[int, Tuple[SessionBatch, Tuple[torch.Tensor]]],
         batch_idx: int,
         split: Literal["train", "valid"],
-    ):
+    ) -> torch.Tensor:
         hps = self.hparams
         # Check that the split argument is valid
         assert split in ["train", "valid"]
@@ -467,7 +467,7 @@ class LFADS(pl.LightningModule):
 
     def training_step(
         self, batch: Dict[int, Tuple[SessionBatch, Tuple[torch.Tensor]]], batch_idx: int
-    ):
+    ) -> torch.Tensor:
         """
         Performs a training step.
 
@@ -488,7 +488,7 @@ class LFADS(pl.LightningModule):
 
     def validation_step(
         self, batch: Dict[int, Tuple[SessionBatch, Tuple[torch.Tensor]]], batch_idx: int
-    ):
+    ) -> torch.Tensor:
         """
         Performs a validation step.
 
@@ -512,7 +512,7 @@ class LFADS(pl.LightningModule):
         batch: Dict[int, Tuple[SessionBatch, Tuple[torch.Tensor]]],
         batch_idx: int,
         sample_posteriors=True,
-    ):
+    ) -> Dict[int, SessionOutput]:
         """
         Performs a prediction step.
 

--- a/lfads_torch/model.py
+++ b/lfads_torch/model.py
@@ -510,6 +510,7 @@ class LFADS(pl.LightningModule):
     def predict_step(
         self,
         batch: Dict[int, Tuple[SessionBatch, Tuple[torch.Tensor]]],
+        batch_idx: int,
         sample_posteriors=True,
     ):
         """


### PR DESCRIPTION
Fixed a type hint (models.py line 199) that was breaking lfads-torch on the main branch. Also added a note in the README regarding config files for multi-session runs.

Edit: also changed "batch_ix" from the call to pl_module.predict_step in callbacks.py (line 106) to "batch_idx" to match the definition of predict_step in model.py (line 513). 