### PR TITLE
fix encoder zero-padding for non-zero ic_enc_seq_len

### DIFF
--- a/lfads_torch/modules/encoder.py
+++ b/lfads_torch/modules/encoder.py
@@ -83,6 +83,8 @@ class Encoder(nn.Module):
             # Add extra zeros if necessary for forward prediction
             fwd_steps = hps.recon_seq_len - hps.encod_seq_len
             ci = F.pad(ci, (0, 0, 0, fwd_steps, 0, 0))
+            # Add extra zeros if encoder does not see whole sequence
+            ci = F.pad(ci, (0, 0, hps.ic_enc_seq_len, 0, 0, 0))
         else:
             # Create a placeholder if there's no controller
             ci = torch.zeros(data.shape[0], hps.recon_seq_len, 0).to(data.device)


### PR DESCRIPTION
Issue and fix by @NinelK:

Non-zero `ic_enc_seq_len` results in:
```
lfads_torch/modules/decoder.py", line 140, in forward
dec_rnn_input = torch.cat([ci, ext_input_drop], dim=2)
RuntimeError: Sizes of tensors must match except in dimension 2. 
Expected size 70 but got size 100 for tensor number 1 in the list.
```
here for `ic_enc_seq_len=30` and `encod_seq_len=recon_seq_len=100`.

The fix is to pad in the [encoder](https://github.com/arsedler9/lfads-torch/blob/d8b4b3ba87a49fd74a3c06afb3ec1b695c6a2227/lfads_torch/modules/encoder.py#L85):
```
83     # Add extra zeros if necessary for forward prediction
84     fwd_steps = hps.recon_seq_len - hps.encod_seq_len
85     ci = F.pad(ci, (0, 0, 0, fwd_steps, 0, 0))
86     # Add extra zeros if encoder does not see whole sequence
87     ci = F.pad(ci, (0, 0, hps.ic_enc_seq_len, 0, 0, 0))
```